### PR TITLE
Add formula for qt 4.8 and update coinbase dependency

### DIFF
--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -13,7 +13,7 @@ class Gridcoin < Formula
   depends_on 'libzip'
   depends_on 'pkg-config' => :build
   depends_on 'qrencode'
-  depends_on 'cartr/qt4/qt'
+  depends_on 'Git-Jiro/jiro/qt@4'
 
   def install
 

--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -13,7 +13,7 @@ class Gridcoin < Formula
   depends_on 'libzip'
   depends_on 'pkg-config' => :build
   depends_on 'qrencode'
-  depends_on 'Git-Jiro/jiro/qt@4'
+  depends_on 'Git-Jiro/jiro/qt'
 
   def install
 

--- a/qt.rb
+++ b/qt.rb
@@ -1,4 +1,4 @@
-class QtAT4 < Formula
+class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -1,0 +1,159 @@
+class QtAT4 < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
+  sha256 "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
+  revision 3
+
+  head "https://code.qt.io/qt/qt.git", :branch => "4.8"
+
+  # Backport of Qt5 commit to fix the fatal build error with Xcode 7, SDK 10.11.
+  # https://code.qt.io/cgit/qt/qtbase.git/commit/?id=b06304e164ba47351fa292662c1e6383c081b5ca
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/480b7142c4e2ae07de6028f672695eb927a34875/qt/el-capitan.patch"
+    sha256 "c8a0fa819c8012a7cb70e902abb7133fc05235881ce230235d93719c47650c4e"
+  end
+
+  # Backport of Qt5 patch to fix an issue with null bytes in QSetting strings.
+  patch do
+    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/41669527a2aac6aeb8a5eeb58f440d3f3498910a/patches/qsetting-nulls.patch"
+    sha256 "0deb4cd107853b1cc0800e48bb36b3d5682dc4a2a29eb34a6d032ac4ffe32ec3"
+  end
+
+  option "with-qt3support", "Build with deprecated Qt3Support module support"
+  option "with-docs", "Build documentation"
+  option "without-webkit", "Build without QtWebKit module"
+
+  depends_on "openssl"
+  depends_on "dbus" => :optional
+  depends_on "mysql" => :optional
+  depends_on "postgresql" => :optional
+
+  deprecated_option "qtdbus" => "with-dbus"
+  deprecated_option "with-d-bus" => "with-dbus"
+
+  resource "test-project" do
+    url "https://gist.github.com/tdsmith/f55e7e69ae174b5b5a03.git",
+        :revision => "6f565390395a0259fa85fdd3a4f1968ebcd1cc7d"
+  end
+
+  def install
+    args = %W[
+      -prefix #{prefix}
+      -release
+      -opensource
+      -confirm-license
+      -fast
+      -system-zlib
+      -qt-libtiff
+      -qt-libpng
+      -qt-libjpeg
+      -nomake demos
+      -nomake examples
+      -cocoa
+    ]
+
+    if ENV.compiler == :clang
+      args << "-platform"
+
+      if MacOS.version >= :mavericks
+        args << "unsupported/macx-clang-libc++"
+      else
+        args << "unsupported/macx-clang"
+      end
+    end
+
+    # Phonon is broken on macOS 10.12+ and Xcode 8+ due to QTKit.framework
+    # being removed.
+    args << "-no-phonon" if MacOS.version >= :sierra || MacOS::Xcode.version >= "8.0"
+
+    args << "-openssl-linked"
+    args << "-I" << Formula["openssl"].opt_include
+    args << "-L" << Formula["openssl"].opt_lib
+
+    args << "-plugin-sql-mysql" if build.with? "mysql"
+    args << "-plugin-sql-psql" if build.with? "postgresql"
+
+    if build.with? "dbus"
+      dbus_opt = Formula["dbus"].opt_prefix
+      args << "-I#{dbus_opt}/lib/dbus-1.0/include"
+      args << "-I#{dbus_opt}/include/dbus-1.0"
+      args << "-L#{dbus_opt}/lib"
+      args << "-ldbus-1"
+      args << "-dbus-linked"
+    end
+
+    if build.with? "qt3support"
+      args << "-qt3support"
+    else
+      args << "-no-qt3support"
+    end
+
+    args << "-nomake" << "docs" if build.without? "docs"
+
+    if MacOS.prefer_64_bit?
+      args << "-arch" << "x86_64"
+    else
+      args << "-arch" << "x86"
+    end
+
+    args << "-no-webkit" if build.without? "webkit"
+
+    system "./configure", *args
+    system "make"
+    ENV.j1
+    system "make", "install"
+
+    # what are these anyway?
+    (bin+"pixeltool.app").rmtree
+    (bin+"qhelpconverter.app").rmtree
+    # remove porting file for non-humans
+    (prefix+"q3porting.xml").unlink if build.without? "qt3support"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # Make `HOMEBREW_PREFIX/lib/qt4/plugins` an additional plug-in search path
+    # for Qt Designer to support formulae that provide Qt Designer plug-ins.
+    system "/usr/libexec/PlistBuddy",
+            "-c", "Add :LSEnvironment:QT_PLUGIN_PATH string \"#{HOMEBREW_PREFIX}/lib/qt4/plugins\"",
+           "#{bin}/Designer.app/Contents/Info.plist"
+
+    Pathname.glob("#{bin}/*.app") { |app| mv app, prefix }
+  end
+
+  def caveats; <<-EOS.undent
+    We agreed to the Qt opensource license for you.
+    If this is unacceptable you should uninstall.
+
+    Qt Designer no longer picks up changes to the QT_PLUGIN_PATH environment
+    variable as it was tweaked to search for plug-ins provided by formulae in
+      #{HOMEBREW_PREFIX}/lib/qt4/plugins
+
+    Phonon is not supported on macOS Sierra or with Xcode 8.
+    EOS
+  end
+
+  test do
+    Encoding.default_external = "UTF-8" unless RUBY_VERSION.start_with? "1."
+    resource("test-project").stage testpath
+    system bin/"qmake"
+    system "make"
+    assert_match(/GitHub/, pipe_output(testpath/"qtnetwork-test 2>&1", nil, 0))
+  end
+
+  bottle do
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "5d7fcd5f7925ed4be7724aa2d1b8e14eef6e9cf786f362138e501c845ed0034f" => :sierra
+    sha256 "933b11d7efbaa066f5ab75ec56e5319e1422dec940d5035b4242e9766d0555f1" => :el_capitan
+    sha256 "63e5b332675a16fa7b13623dfa577cb49579d56b9fe43b2f8f04b0747a4ae80a" => :yosemite
+  end
+end


### PR DESCRIPTION
Copying [cartr/homebrew-qt4](https://github.com/cartr/homebrew-qt4) both as a backup and so Gridcoin users on Mac don't have to tap multiple repos

As mentioned here: https://cryptocointalk.com/topic/13139-os-x-builds-feedback-bug-reporting/page-14