### PR TITLE
Include stable and development versions; Add upnp option as default

### DIFF
--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -1,13 +1,17 @@
 class Gridcoin < Formula
   desc "GridCoin OS X client (GUI and CLI)"
   homepage "http://gridcoin.us"
-  head "https://github.com/gridcoin/Gridcoin-Research.git", :revision => '6422a1b74e7c8'
+  url "https://github.com/gridcoin/Gridcoin-Research/archive/3.5.8.6.tar.gz"
+  sha256 "d798ea60f87d4daf78c154dde650f0cb08cc28cc34fa8ee876c2e37948efb393"
+  
+  head "https://github.com/gridcoin/Gridcoin-Research.git", :branch => "development"
 
+  option "without-upnp", "Do not compile with UPNP support"
   option "with-cli", "Also compile the command line client"
   option "without-gui", "Do not compile the graphical client"
 
   depends_on 'boost'
-  depends_on 'berkeley-db4'
+  depends_on 'berkeley-db@4'
   depends_on 'openssl'
   depends_on 'miniupnpc'
   depends_on 'libzip'
@@ -17,15 +21,21 @@ class Gridcoin < Formula
 
   def install
 
+    if build.with? 'upnp'
+      upnp_build_var = '1'
+    else
+      upnp_build_var = '-'
+    end
+
     if build.with? 'cli'
       chmod 0755, "src/leveldb/build_detect_platform"
       mkdir_p "src/obj/zerocoin"
-      system "make", "-C", "src", "-f", "makefile.osx", "USE_UPNP=-"
+      system "make", "-C", "src", "-f", "makefile.osx", "USE_UPNP=#{upnp_build_var}"
       bin.install "src/gridcoinresearchd"
     end
 
     if build.with? 'gui'
-      system "qmake", "USE_UPNP=-"
+      system "qmake", "USE_UPNP=#{upnp_build_var}"
       system "make"
       prefix.install "gridcoinresearch.app"
     end


### PR DESCRIPTION
In response to Marco Nilsson asking for someone to test the development branch I've updated the formula to recognise the latest stable and for `--HEAD` to pull from the development branch.

Also added UPNP support and the option to compile without