### PR TITLE
Hopefully fix `brew upgrade gridcoin` and add --devel flag

### DIFF
--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -7,7 +7,7 @@ class Gridcoin < Formula
   head "https://github.com/gridcoin/Gridcoin-Research.git", :branch => "master"
 
   devel do
-    url "https://github.com/gridcoin/Gridcoin-Research.git", :using => :git, :branch => "development"
+    url "https://github.com/gridcoin/Gridcoin-Research.git", :using => :git, :branch => "staging"
     version "3.5.8.8b-dev"
   end
 

--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -2,8 +2,14 @@ class Gridcoin < Formula
   desc "OS X client (GUI and CLI)"
   homepage "https://gridcoin.us/"
   url "https://github.com/gridcoin/Gridcoin-Research/archive/3.5.8.8b.tar.gz"
+  version "3.5.8.8b"
   sha256 "601190f4438f8be762bfeea1dfd50d5fad4cd916c2c5bc92e24ae31b417bdcd6"
-  head "https://github.com/gridcoin/Gridcoin-Research.git", :branch => "development"
+  head "https://github.com/gridcoin/Gridcoin-Research.git", :branch => "master"
+
+  devel do
+    url "https://github.com/gridcoin/Gridcoin-Research.git", :using => :git, :branch => "development"
+    version "3.5.8.8b-dev"
+  end
 
   option "without-upnp", "Do not compile with UPNP support"
   option "with-cli", "Also compile the command line client"


### PR DESCRIPTION
Added explicit version numbering so homebrew knows when the version changes.

Also added a `--devel` block to build from the development branch and changed `--HEAD` back to the head of the master branch to match homebrew's formula conventions. Development builds have `-dev` appended to the version declaration to separate from stable so homebrew will agree to build it.
Note that I can't get the development branch to build at the moment, which is probably due to Qt changes.

I know I've changed up `--HEAD` a couple of times already, so if you want to reject that part I am okay with that