### PR TITLE
Use latest boost version

### DIFF
--- a/gridcoin.rb
+++ b/gridcoin.rb
@@ -76,7 +76,7 @@ class Gridcoin < Formula
   option "with-cli", "Also compile the command line client"
   option "without-gui", "Do not compile the graphical client"
 
-  depends_on "boost@1.60"
+  depends_on "boost"
   depends_on "berkeley-db@4"
   depends_on "leveldb"
   depends_on "openssl"
@@ -106,8 +106,8 @@ class Gridcoin < Formula
 
     if build.with? "gui"
       args = %W[
-        BOOST_INCLUDE_PATH=#{Formula["boost@1.60"].include}
-        BOOST_LIB_PATH=#{Formula["boost@1.60"].lib}
+        BOOST_INCLUDE_PATH=#{Formula["boost"].include}
+        BOOST_LIB_PATH=#{Formula["boost"].lib}
         OPENSSL_INCLUDE_PATH=#{Formula["openssl"].include}
         OPENSSL_LIB_PATH=#{Formula["openssl"].lib}
         BDB_INCLUDE_PATH=#{Formula["berkeley-db@4"].include}
@@ -119,7 +119,7 @@ class Gridcoin < Formula
       ]
 
       system "./autogen.sh"
-      system "unset OBJCXX ; ./configure --with-boost=#{Formula["boost@1.60"].lib}/.."
+      system "unset OBJCXX ; ./configure"
       system "make appbundle"
       prefix.install "gridcoinresearch.app"
     end


### PR DESCRIPTION
Version 4.0.6.0 no longer requires an older version of boost. In fact for me, the build failed without these changes, but that could have been caused by other issues in my environment.