### PR TITLE
Change Filenames | Fix 5.3.1.0 Build & Clarify Output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,10 @@ jobs:
 
       - name: build gridcoin dmg
         run: |
-          cd `brew --prefix`/Cellar/gridcoin/* && `brew --prefix`/Cellar/qt@5/*/bin/macdeployqt gridcoinresearch.app -verbose=2 -dmg
+          cd `brew --prefix`/Cellar/gridcoin/* && `brew --prefix`/Cellar/qt@5/*/bin/macdeployqt Gridcoin.app -verbose=2 -dmg
           pwd
           ls
-          cp gridcoinresearch.dmg $GITHUB_WORKSPACE/gridcoinresearch_bigsur.dmg
+          cp Gridcoin.dmg $GITHUB_WORKSPACE/gridcoinresearch_bigsur_or_mojave.dmg
 
       - name: Create Release
         id: create_release
@@ -59,6 +59,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ${{ github.workspace }}/gridcoinresearch_bigsur.dmg
-          asset_name: gridcoinresearch_bigsur.dmg
+          asset_path: ${{ github.workspace }}/gridcoinresearch_bigsur_or_mojave.dmg
+          asset_name: gridcoinresearch_bigsur_or_mojave.dmg
           asset_content_type: application/zip

--- a/Formula/gridcoin.rb
+++ b/Formula/gridcoin.rb
@@ -79,7 +79,7 @@ class Gridcoin < Formula
 
     if build.with? "gui"
       system "make", "appbundle"
-      prefix.install "gridcoinresearch.app"
+      prefix.install "Gridcoin.app"
     end
   end
 
@@ -87,6 +87,6 @@ class Gridcoin < Formula
     system bin/"gridcoinresearchd", "-version" if build.with? "cli"
 
     # Currently help is the only flag which does not actually start the gui
-    system prefix/"gridcoinresearch.app/Contents/MacOS/gridcoinresearch", "-?" if build.with? "gui"
+    system prefix/"Gridcoin.app/Contents/MacOS/gridcoinresearch", "-?" if build.with? "gui"
   end
 end


### PR DESCRIPTION
@Git-Jiro whenever you get the chance can you merge this and trigger a build? You may need to untag the 5.3.10 release first. This should fix the error that happened in the last build. There was a change to the makefile in 5.3.1.0 which changed filenames thus causing the build to fail 


Name changes to deal with the makefile change:
`gridcoinresearch.app` -> `Gridcoin.app`
`gridcoinresearch.dmg` -> `Gridcoin.dmg`

Name changes for the output:
`gridcoinresearch_bigsur.dmg` -> `gridcoinresearch_bigsur_or_mojave.dmg` to clarify that it works on both Bigsur and Mojave